### PR TITLE
Removed system hooks

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -2,10 +2,7 @@ package broker
 
 import (
 	"errors"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 )
 
 //A broker to which cache broker will send messages published to all subscribed users.
@@ -14,7 +11,6 @@ type Broker struct {
 	userUnsubscribed chan *Event
 	users            map[chan string]bool
 	data             chan string
-	systemEvents     chan os.Signal
 	wg               *sync.WaitGroup
 }
 
@@ -32,14 +28,11 @@ type Result struct {
 
 //Create a new broker instance.
 func NewBroker() *Broker {
-	systemEvents := make(chan os.Signal)
-	signal.Notify(systemEvents, syscall.SIGINT, syscall.SIGTERM)
 	return &Broker{
 		userSubscribed:   make(chan *Event),
 		userUnsubscribed: make(chan *Event),
 		users:            make(map[chan string]bool),
 		data:             make(chan string),
-		systemEvents:     systemEvents,
 	}
 }
 
@@ -78,15 +71,6 @@ func (b *Broker) Run() {
 			for user := range b.users {
 				user <- data
 			}
-		case <-b.systemEvents:
-			for user := range b.users {
-				close(user)
-				delete(b.users, user)
-			}
-			if b.wg != nil {
-				b.wg.Done()
-			}
-			return
 		}
 	}
 }

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -2,8 +2,6 @@ package broker
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
-	"sync"
-	"syscall"
 	"testing"
 )
 
@@ -68,24 +66,6 @@ func TestPublishMessage(t *testing.T) {
 			broker.Publish("Hello world!")
 			Convey("Then the message should be published to all subscribers", func() {
 				So(<-user, ShouldEqual, "Hello world!")
-			})
-		})
-	})
-}
-
-func TestStopBrokerIfSystemSignalReceived(t *testing.T) {
-	Convey("Given a running broker instance with a subscribed user", t, func() {
-		waitGroup := new(sync.WaitGroup)
-		broker := NewBroker()
-		broker.wg = waitGroup
-		go broker.Run()
-		_, _ = broker.Subscribe()
-		Convey("When a system signal is sent", func() {
-			waitGroup.Add(1)
-			broker.systemEvents <- syscall.SIGTERM
-			waitGroup.Wait()
-			Convey("Then all users should be stopped and removed", func() {
-				So(broker.users, ShouldBeEmpty)
 			})
 		})
 	})


### PR DESCRIPTION
Shutdown hook was causing stray newlines to be added to output to connected users.